### PR TITLE
FIX /  Precio Temporal Campo Vacío 

### DIFF
--- a/src/components/Config/components/TemporaryPrices.tsx
+++ b/src/components/Config/components/TemporaryPrices.tsx
@@ -12,7 +12,6 @@ const TemporaryPrices = () => {
    const dispatch = useDispatch();
    const { control, handleSubmit, reset } = useForm()
    const [temporaryPrices, setTemporaryPrices] = useState<any>([])
-   const [refreshPrices, setRefreshPrices] = useState<boolean>(true)
 
    useEffect(() => {
       getTemporaryPrices().then(res => setTemporaryPrices(res.data))
@@ -30,7 +29,7 @@ const TemporaryPrices = () => {
          return auxObj
       }
       reset(pricesInputDefault())
-   }, [temporaryPrices, refreshPrices])
+   }, [temporaryPrices])
 
    const onSubmit = async (data: any) => {
       const inputHasText = () => {


### PR DESCRIPTION
- Ahora, si se borra un campo y se envía vacío, se hace la petición, y al refrescar el back devuelve 0. Antes si estaba vacío te tiraba error de Input con Texto.